### PR TITLE
require open3 explicitly

### DIFF
--- a/lib/xcjobs/xcodebuild.rb
+++ b/lib/xcjobs/xcodebuild.rb
@@ -1,5 +1,6 @@
 require 'rake/tasklib'
 require 'rake/clean'
+require 'open3'
 
 module XCJobs
   class Xcodebuild < Rake::TaskLib


### PR DESCRIPTION
Otherwise it would cause "NameError: uninitialized constant XCJobs::Xcodebuild::Open3" in Ruby 2.2
