### PR TITLE
require date explicitly

### DIFF
--- a/spec/distribute_spec.rb
+++ b/spec/distribute_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'date'
 
 describe XCJobs::Distribute do
   before(:each) do


### PR DESCRIPTION
I found a fail of tests in 2.0.0.

```
Failures:

  1) XCJobs::Distribute XCJobs::Distribute::TestFlight define upload ipa task configures the ipa file path
     Failure/Error: let(:notes) { "Uploaded: #{DateTime.now.strftime("%Y/%m/%d %H:%M:%S")}" }
     NameError:
       uninitialized constant DateTime
     # ./spec/distribute_spec.rb:33:in `block (4 levels) in <top (required)>'
     # ./spec/distribute_spec.rb:43:in `block (5 levels) in <top (required)>'
     # ./lib/xcjobs/distribute.rb:48:in `initialize'
     # ./spec/distribute_spec.rb:36:in `new'
     # ./spec/distribute_spec.rb:36:in `block (4 levels) in <top (required)>'

# ...

Finished in 1.45 seconds (files took 0.12903 seconds to load)
72 examples, 8 failures
```

2.0.0 is system Ruby version of OS X Yosemite. 

```
/usr/bin/ruby -v
ruby 2.0.0p481 (2014-05-08 revision 45883) [universal.x86_64-darwin14]
```
