### PR TITLE
scheme can include half-width space

### DIFF
--- a/lib/xcjobs/xcodebuild.rb
+++ b/lib/xcjobs/xcodebuild.rb
@@ -241,8 +241,8 @@ module XCJobs
 
           run(['xcodebuild', 'archive'] + options)
 
-          sh %[(cd "#{build_dir}"; zip -ryq "dSYMs.zip" #{File.join("#{scheme}.xcarchive", "dSYMs")})] if build_dir && scheme
-          sh %[(cd "#{build_dir}"; zip -ryq #{scheme}.xcarchive.zip #{scheme}.xcarchive)] if build_dir && scheme
+          sh %[(cd "#{build_dir}"; zip -ryq "dSYMs.zip" "#{File.join("#{scheme}.xcarchive", "dSYMs")}")] if build_dir && scheme
+          sh %[(cd "#{build_dir}"; zip -ryq #{scheme}.xcarchive.zip "#{scheme}.xcarchive")] if build_dir && scheme
         end
       end
     end

--- a/spec/xcodebuild_spec.rb
+++ b/spec/xcodebuild_spec.rb
@@ -392,8 +392,8 @@ describe XCJobs::Xcodebuild do
           it 'executes the appropriate commands' do
             subject.invoke
             expect(@commands).to eq [ 'xcodebuild archive -project Example.xcodeproj -scheme Example -configuration Release -derivedDataPath build CONFIGURATION_TEMP_DIR=build/temp -archivePath build/Example',
-              '(cd "build"; zip -ryq "dSYMs.zip" Example.xcarchive/dSYMs)',
-              '(cd "build"; zip -ryq Example.xcarchive.zip Example.xcarchive)',
+              '(cd "build"; zip -ryq "dSYMs.zip" "Example.xcarchive/dSYMs")',
+              '(cd "build"; zip -ryq Example.xcarchive.zip "Example.xcarchive")',
             ]
           end
         end
@@ -457,13 +457,13 @@ describe XCJobs::Xcodebuild do
 
             if ENV['CI']
               expect(@commands).to eq [ 'xcodebuild archive -workspace Example.xcworkspace -scheme Example -configuration Release -derivedDataPath build CONFIGURATION_TEMP_DIR=build/temp CODE_SIGN_IDENTITY=iPhone Distribution: kishikawa katsumi -archivePath build/Example',
-                '(cd "build"; zip -ryq "dSYMs.zip" Example.xcarchive/dSYMs)',
-                '(cd "build"; zip -ryq Example.xcarchive.zip Example.xcarchive)',
+                '(cd "build"; zip -ryq "dSYMs.zip" "Example.xcarchive/dSYMs")',
+                '(cd "build"; zip -ryq Example.xcarchive.zip "Example.xcarchive")',
               ]
             else
               expect(@commands).to eq [ 'xcodebuild archive -workspace Example.xcworkspace -scheme Example -configuration Release -derivedDataPath build CONFIGURATION_TEMP_DIR=build/temp CODE_SIGN_IDENTITY=iPhone Distribution: kishikawa katsumi PROVISIONING_PROFILE=5d09b88d-ff09-43aa-a6fd-3907f98fe467 -archivePath build/Example',
-                '(cd "build"; zip -ryq "dSYMs.zip" Example.xcarchive/dSYMs)',
-                '(cd "build"; zip -ryq Example.xcarchive.zip Example.xcarchive)',
+                '(cd "build"; zip -ryq "dSYMs.zip" "Example.xcarchive/dSYMs")',
+                '(cd "build"; zip -ryq Example.xcarchive.zip "Example.xcarchive")',
               ]
             end
           end


### PR DESCRIPTION
```ruby
XCJobs::Archive.new do |t|
  t.workspace = 'Example'
  t.scheme = 'Example Scheme'
  t.configuration = 'Release'
  t.build_dir = 'build'
end
```

```sh
$ rake build:archive
(cd
"/path/to/build";
zip -ryq "dSYMs.zip" Example Scheme.xcarchive/dSYMs)

zip error: Nothing to do! (try: zip -ryq dSYMs.zip . -i
Example Scheme.xcarchive/dSYMs)
```

:bow: 

schemeが空白を含んでいた場合、`:archive`の`zip`コマンドでエラーとなります。