### PR TITLE
Clear env vars on xcodebuild

### DIFF
--- a/lib/xcjobs/xcodebuild.rb
+++ b/lib/xcjobs/xcodebuild.rb
@@ -82,8 +82,11 @@ module XCJobs
         puts cmd.join(" ")
       end
 
+      env = {}
+      options = { unsetenv_others: true }
+
       if @formatter
-        Open3.pipeline_r(cmd, [@formatter]) do |stdout, wait_thrs|
+        Open3.pipeline_r([env] + cmd + [options], [@formatter]) do |stdout, wait_thrs|
           output = []
           while line = stdout.gets
             puts line
@@ -98,7 +101,7 @@ module XCJobs
           end
         end
       else
-        Open3.popen2e(*cmd) do |stdin, stdout_err, wait_thr|
+        Open3.popen2e(env, *cmd, options) do |stdin, stdout_err, wait_thr|
           output = []
           while line = stdout_err.gets
             puts line

--- a/lib/xcjobs/xcodebuild.rb
+++ b/lib/xcjobs/xcodebuild.rb
@@ -26,12 +26,15 @@ module XCJobs
     attr_reader :provisioning_profile_name
     attr_reader :provisioning_profile_uuid
 
+    attr_accessor :unsetenv_others
+
     def initialize(name)
       $stdout.sync = $stderr.sync = true
       
       @name = name
       @destinations = []
       @build_settings = {}
+      @unsetenv_others = false
     end
 
     def project
@@ -83,7 +86,7 @@ module XCJobs
       end
 
       env = {}
-      options = { unsetenv_others: true }
+      options = { unsetenv_others: unsetenv_others }
 
       if @formatter
         Open3.pipeline_r([env] + cmd + [options], [@formatter]) do |stdout, wait_thrs|
@@ -357,6 +360,7 @@ module XCJobs
 
     def initialize(name = :export)
       super
+      self.unsetenv_others = true
       yield self if block_given?
       define
     end

--- a/spec/xcodebuild_spec.rb
+++ b/spec/xcodebuild_spec.rb
@@ -334,6 +334,29 @@ describe XCJobs::Xcodebuild do
         end
       end
     end
+
+    describe 'unsetenv_others' do
+      it 'defaults to false' do
+        task = XCJobs::Build.new do |t|
+          t.project = 'Example.xcodeproj'
+          t.target = 'Example'
+          t.configuration = 'Release'
+        end
+
+        expect(task.unsetenv_others).to eq false
+      end
+
+      it 'can be configured' do
+        task = XCJobs::Build.new do |t|
+          t.project = 'Example.xcodeproj'
+          t.target = 'Example'
+          t.configuration = 'Release'
+          t.unsetenv_others = true
+        end
+
+        expect(task.unsetenv_others).to eq true
+      end
+    end
   end
 
   describe XCJobs::Archive do
@@ -510,6 +533,10 @@ describe XCJobs::Xcodebuild do
 
       it 'configures the export signing identity' do
         expect(task.export_signing_identity).to eq 'iPhone Distribution: kishikawa katsumi'
+      end
+
+      it 'configures unsetenv_others to true by default' do
+        expect(task.unsetenv_others).to be_truthy
       end
 
       describe 'tasks' do


### PR DESCRIPTION
Because `xcodebuild -exportArchive` runs `ruby` internally, passing `ruby` related env vars to `xcodebuild` may lead to an error.

This PR is to clear env vars on `xcodebuild` invocation.