### PR TITLE
Support -exportOptionsPlist option

### DIFF
--- a/lib/xcjobs/xcodebuild.rb
+++ b/lib/xcjobs/xcodebuild.rb
@@ -351,6 +351,7 @@ module XCJobs
     attr_accessor :export_signing_identity
     attr_accessor :export_installer_identity
     attr_accessor :export_with_original_signing_identity
+    attr_accessor :options_plist
 
     def initialize(name = :export)
       super
@@ -389,6 +390,7 @@ module XCJobs
 
     def options
       [].tap do |opts|
+        opts.concat(['-exportOptionsPlist', options_plist]) if options_plist
         opts.concat(['-archivePath', archive_path]) if archive_path
         opts.concat(['-exportFormat', export_format])  if export_format
         opts.concat(['-exportPath', export_path]) if export_path

--- a/lib/xcjobs/xcodebuild.rb
+++ b/lib/xcjobs/xcodebuild.rb
@@ -354,6 +354,7 @@ module XCJobs
 
     def initialize(name = :export)
       super
+      @export_format = 'IPA'
       yield self if block_given?
       define
     end
@@ -363,7 +364,7 @@ module XCJobs
     end
 
     def export_format
-      @export_format || 'IPA'
+      @export_format
     end
 
     def export_provisioning_profile=(provisioning_profile)

--- a/spec/xcodebuild_spec.rb
+++ b/spec/xcodebuild_spec.rb
@@ -616,6 +616,32 @@ describe XCJobs::Xcodebuild do
       end
     end
 
+    describe 'export task for IPA' do
+      let!(:task) do
+        XCJobs::Export.new do |t|
+          t.archive_path = 'build/Example'
+          t.export_format = nil
+          t.export_path = 'build'
+          t.options_plist = 'options.plist'
+        end
+      end
+
+      it 'configures the export options plist' do
+        expect(task.options_plist).to eq 'options.plist'
+      end
+
+      describe 'tasks' do
+        describe 'export' do
+          subject { Rake.application['build:export'] }
+
+          it 'executes the appropriate commands' do
+            subject.invoke
+            expect(@commands).to eq ['xcodebuild -exportArchive -exportOptionsPlist options.plist -archivePath build/Example -exportPath build']
+          end
+        end
+      end
+    end
+
     describe 'export task for PKG' do
       let!(:task) do
         XCJobs::Export.new do |t|

--- a/spec/xcodebuild_spec.rb
+++ b/spec/xcodebuild_spec.rb
@@ -567,6 +567,55 @@ describe XCJobs::Xcodebuild do
       end
     end
 
+    describe 'export task for IPA' do
+      let!(:task) do
+        XCJobs::Export.new do |t|
+          t.archive_path = 'build/Example'
+          t.export_format = nil
+          t.export_path = 'build'
+        end
+      end
+
+      it 'configures the export_format to be nil' do
+        expect(task.export_format).to be_nil
+      end
+
+      describe 'tasks' do
+        describe 'export' do
+          subject { Rake.application['build:export'] }
+
+          it 'executes the appropriate commands' do
+            subject.invoke
+            expect(@commands).to eq ['xcodebuild -exportArchive -archivePath build/Example -exportPath build']
+          end
+        end
+      end
+    end
+
+    describe 'export task for IPA' do
+      let!(:task) do
+        XCJobs::Export.new do |t|
+          t.archive_path = 'build/Example'
+          t.export_path = 'build'
+        end
+      end
+
+      it 'has default export_format default to be IPA' do
+        expect(task.export_format).to eq 'IPA'
+      end
+
+      describe 'tasks' do
+        describe 'export' do
+          subject { Rake.application['build:export'] }
+
+          it 'executes the appropriate commands' do
+            subject.invoke
+            expect(@commands).to eq ['xcodebuild -exportArchive -archivePath build/Example -exportFormat IPA -exportPath build']
+          end
+        end
+      end
+    end
+
     describe 'export task for PKG' do
       let!(:task) do
         XCJobs::Export.new do |t|


### PR DESCRIPTION
`xcodebuild -exportArchive` now accepts `-exportOptionsPlist`. This PR is to support that.

* Allow to skip `-exportFormat` option, because it cannot be used with `-exportOptionsPlist`